### PR TITLE
Use php 7.4.* as default version

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -7,7 +7,7 @@ version = "{{ .Version }}"
 homepage = "https://github.com/paketo-buildpacks/php-web"
 
 [metadata]
-default_version = "7.2.*"
+default_version = "7.4.*"
 include_files = ["bin/build","bin/detect","bin/procmgr","bin/session_helper","buildpack.toml"]
 pre_package = "./scripts/build.sh"
 


### PR DESCRIPTION
php-dist v0.1.0 doesn't support 7.2.* anymore


Please confirm the following:
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
