### PR TITLE
Expose dynamic extensions in buildpack.yml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,7 @@ type Config struct {
 	WebServer           string    `yaml:"webserver"`
 	WebDirectory        string    `yaml:"webdirectory"`
 	LibDirectory        string    `yaml:"libdirectory"`
+	Extensions          string    `yaml:"extensions"`
 	Script              string    `yaml:"script"`
 	ServerAdmin         string    `yaml:"serveradmin"`
 	EnableHTTPSRedirect bool      `yaml:"enable_https_redirect"`

--- a/features/php.go
+++ b/features/php.go
@@ -1,11 +1,13 @@
 package features
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/buildpack/libbuildpack/application"
 	"github.com/cloudfoundry/libcfbuildpack/layers"
 	"github.com/paketo-buildpacks/php-web/config"
-	"os"
-	"path/filepath"
 )
 
 type PhpFeature struct {
@@ -44,6 +46,7 @@ func (p PhpFeature) writePhpIni(layer layers.Layer) error {
 	phpIniCfg := config.PhpIniConfig{
 		AppRoot:      p.app.Root,
 		LibDirectory: p.bpYAML.Config.LibDirectory,
+		Extensions:   strings.Split(p.bpYAML.Config.Extensions, ","),
 		PhpHome:      os.Getenv("PHP_HOME"),
 		PhpAPI:       os.Getenv("PHP_API"),
 	}


### PR DESCRIPTION
[Fixes #124]

This way the user can enable dynamic extensions in php.ini with
something like:

```
php:
  extensions: 'zlib,gd'
```

Signed-off-by: Dimitris Karakasilis <DKarakasilis@suse.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Some PHP applications require functions like `gzinflate()` (see here for original issue with Wordpress: https://github.com/SUSE/carrier/issues/144) which are only available if `extension=zlib` exists in php.ini .

## Use Cases
<!-- An explanation of the use cases your change enables -->
Create an image for Wordpress with this buildpack.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
