### PR TITLE
Allow ".well-known" locations

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -58,7 +58,7 @@ func testPhpAppConfig(t *testing.T, when spec.G, it spec.S) {
 			Expect(result).To(ContainSubstring(`ServerAdmin "test@example.org"`))
 			Expect(result).To(ContainSubstring(`DocumentRoot "/app/htdocs"`))
 			Expect(result).To(ContainSubstring(`<Directory "/app/htdocs">`))
-			Expect(result).To(ContainSubstring(`<Files ".ht*">`))
+			Expect(result).To(ContainSubstring(`<FilesMatch "^\.">`))
 			Expect(result).To(ContainSubstring(`ErrorLog "/proc/self/fd/2"`))
 			Expect(result).To(ContainSubstring(`CustomLog "/proc/self/fd/1" extended`))
 			Expect(result).To(ContainSubstring(`RemoteIpHeader x-forwarded-for`))

--- a/config/httpd.go
+++ b/config/httpd.go
@@ -62,7 +62,7 @@ LoadModule headers_module modules/mod_headers.so
     Require all denied
 </DirectoryMatch>
 
-<DirectoryMatch "^\.well-known">
+<DirectoryMatch /.well-known>
     Require all granted
 </DirectoryMatch>
 

--- a/config/httpd.go
+++ b/config/httpd.go
@@ -54,9 +54,9 @@ LoadModule headers_module modules/mod_headers.so
     Require all granted
 </Directory>
 
-<Files ".ht*">
+<FilesMatch "^\.">
     Require all denied
-</Files>
+</FilesMatch>
 
 # set up mime types
 <IfModule mime_module>

--- a/config/httpd.go
+++ b/config/httpd.go
@@ -58,6 +58,14 @@ LoadModule headers_module modules/mod_headers.so
     Require all denied
 </FilesMatch>
 
+<DirectoryMatch "^\.|\/\.">
+    Require all denied
+</DirectoryMatch>
+
+<DirectoryMatch "^\.well-known">
+    Require all granted
+</DirectoryMatch>
+
 # set up mime types
 <IfModule mime_module>
     TypesConfig conf/mime.types

--- a/config/nginx.go
+++ b/config/nginx.go
@@ -169,8 +169,8 @@ http {
         }
 {{end}}
 
-        # Deny hidden files (.htaccess, .htpasswd, .DS_Store).
-        location ~ /\. {
+        # Deny hidden files (.htaccess, .htpasswd, .DS_Store) but allow .well-known locations
+        location ~ /\.(?!well-known).* {
             deny            all;
             access_log      off;
             log_not_found   off;

--- a/config/nginx.go
+++ b/config/nginx.go
@@ -169,8 +169,13 @@ http {
         }
 {{end}}
 
-        # Deny hidden files (.htaccess, .htpasswd, .DS_Store) but allow .well-known locations
-        location ~ /\.(?!well-known).* {
+        # Allow "Well-Known URIs" as per RFC 8615
+        location ~* ^/.well-known/ {
+            allow all;
+        }
+        
+        # Deny hidden files (.htaccess, .htpasswd, .DS_Store)
+        location ~ /\. {
             deny            all;
             access_log      off;
             log_not_found   off;


### PR DESCRIPTION
## Summary
This pull request changes the pre-generated NGINX and HTTPD configuration of the buildpack and changes the behaviour of the web server if a developer wants to provide a "well known location" according to [RFC 8615](https://tools.ietf.org/html/rfc8615) or a potential client wants to call this URL.

Until now, these requests were answered by NGINX with "403 Forbidden", since all paths beginning with a dot were automatically considered to be rejected. This pull request explicitly excludes ".well-known" from this rule and thus allows its publication.

In addition, the HTTPD configuration becomes more restrictive and, like NGINX, now blocks the delivery of all dotfiles.

## Use Cases
"Well known locations" are used for a wide set of protocols and applications, e.g. Open ID. This change allows the PHP buildpack to be used together with these standardised protocols out-of-the-box, without a developer having to use custom NGINX configurations.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
